### PR TITLE
increase header's z-index

### DIFF
--- a/components/header.tsx
+++ b/components/header.tsx
@@ -29,7 +29,7 @@ export const Header = () => {
   }, [setHamburgerMenuIsOpen]);
 
   return (
-    <header className="fixed top-0 left-0 z-10 w-full border-b border-transparent-white backdrop-blur-[12px]">
+    <header className="fixed top-0 left-0 z-[11] w-full border-b border-transparent-white backdrop-blur-[12px]">
       <Container className="flex h-navigation-height">
         <Link className="flex items-center text-md" href="/">
           <Logo className="mr-4 h-[1.8rem] w-[1.8rem]" /> Linear


### PR DESCRIPTION
otherwise, images in sections EnjoyIssueTracking, BuildMomentum and SetDirection scroll over the header

![Screenshot 2023-02-18 at 03 15 44](https://user-images.githubusercontent.com/59510085/219814992-612e10f0-eb03-4d7e-96ef-a9e2cadc9415.png)
