### PR TITLE
fix: replace transition-[shadow,...] with transition-[box-shadow,...]

### DIFF
--- a/components/button.tsx
+++ b/components/button.tsx
@@ -22,7 +22,7 @@ const buttonClasses = cva("relative rounded-full inline-flex items-center", {
   variants: {
     variant: {
       primary: [
-        "bg-primary-gradient hover:text-shadow hover:shadow-primary transition-[shadow,text-shadow]",
+        "bg-primary-gradient hover:text-shadow hover:shadow-primary transition-[box-shadow,text-shadow]",
         "[&_.highlight]:ml-2",
       ],
       secondary: [


### PR DESCRIPTION
the transition: shadow; property doesn't exist in plain CSS, so we needed to replace it with box-shadow to reach the desirable effect